### PR TITLE
Refresh (and clean) listeners when `db` changes

### DIFF
--- a/src/useDrizzleStudio.tsx
+++ b/src/useDrizzleStudio.tsx
@@ -38,5 +38,5 @@ export default function useDrizzleStudio(db: SQLite.SQLiteDatabase | null) {
                 subscription?.remove();
             }
         };
-    }, [client]);
+    }, [client, db]);
 }


### PR DESCRIPTION
Trying to find a solution to this issue [Studio presents an empty page on all browsers #7](https://github.com/drizzle-team/drizzle-studio-expo/issues/7) I've realized that the library is not prepared to allow passing diferents databases or passing `null` or `undefined` as a first value (common if the `db` instance comes from another hook that get the instance asynchronously).

As I've commented in [here](https://github.com/drizzle-team/drizzle-studio-expo/issues/7) this library fails as the some people complains in the issue above with a blank screen when you retrieve the instance like this:

```ts
...
import { useDrizzleStudio } from 'expo-drizzle-studio-plugin';
...

export default function App() {
  const db = useDb();
  useDrizzleStudio(db);
  
  return (
    ...
  )
}
```

Personally, I patched this library because I'm only able to get the instance of `db` asynchronously and there is not any way to fix it apart from this PR. 

Please, if you need to update something in this PR to be compliant let me know to accomplish it ASAP.